### PR TITLE
Fix memory leak in destructor of VortexSimulation

### DIFF
--- a/src/RcsPhysics/VortexSimulation.cpp
+++ b/src/RcsPhysics/VortexSimulation.cpp
@@ -244,6 +244,8 @@ Rcs::VortexSimulation::~VortexSimulation()
   Vx::VxFrame* frame = Vx::VxFrame::instance();
 
   frame->removeUniverse(this->universe);
+  // removeUniverse doesn't delete it!
+  delete this->universe;
 
   if (frame->getUniverseCount()==0)
   {


### PR DESCRIPTION
The VxUniverse object did not get destroyed. 