### PR TITLE
Compute velocity forward kinematics in MotionControlLayer

### DIFF
--- a/src/RcsCore/MotionControlLayer.cpp
+++ b/src/RcsCore/MotionControlLayer.cpp
@@ -30,6 +30,7 @@ Rcs::MotionControlLayer::MotionControlLayer():
   callbackTriggerComponent(NULL),
   ownsDesiredGraph(false),
   stepMe(false),
+  fkComputeVelocity(true),
   emergency(false),
   loopCount(0), overruns(0),
   dtMin(1.0), dtMax(0.0), dtDesired(0.0), sum(0.0)
@@ -45,6 +46,7 @@ Rcs::MotionControlLayer::MotionControlLayer(const char* xmlFile):
   callbackTriggerComponent(NULL),
   ownsDesiredGraph(true),
   stepMe(false),
+  fkComputeVelocity(true),
   emergency(false),
   loopCount(0), overruns(0),
   dtMin(1.0), dtMax(0.0), dtDesired(0.0), sum(0.0)
@@ -161,8 +163,8 @@ void Rcs::MotionControlLayer::updateGraph()
     componentVec[i]->updateGraph(this->currentGraph);
   }
 
-  RcsGraph_setState(this->desiredGraph, NULL, NULL);
-  RcsGraph_setState(this->currentGraph, NULL, NULL);
+  RcsGraph_setState(this->desiredGraph, NULL, fkComputeVelocity ? this->desiredGraph->q_dot : NULL);
+  RcsGraph_setState(this->currentGraph, NULL, fkComputeVelocity ? this->currentGraph->q_dot : NULL);
 
   for (size_t i=0; i<componentVec.size(); ++i)
   {
@@ -532,4 +534,12 @@ void Rcs::MotionControlLayer::stopThreads()
   {
     componentVec[i]->stopThread();
   }
+}
+
+/*******************************************************************************
+ *
+ ******************************************************************************/
+void Rcs::MotionControlLayer::setFKComputeVelocity(bool doit)
+{
+    fkComputeVelocity = doit;
 }

--- a/src/RcsCore/MotionControlLayer.h
+++ b/src/RcsCore/MotionControlLayer.h
@@ -150,6 +150,14 @@ public:
 
   bool getEmergency() const;
 
+  /**
+   * Control whether the forward kinematics of the velocities should be computed.
+   *
+   * This is true by default. However, if you don't need the velocity information
+   * and want to avoid the computation cost, you can set this to false.
+   */
+  void setFKComputeVelocity(bool doit);
+
   virtual void startThreads();
   virtual void stopThreads();
 
@@ -170,6 +178,7 @@ private:
   static void staticCallback(void* param);
   bool ownsDesiredGraph;
   bool stepMe;
+  bool fkComputeVelocity;
   bool emergency;
   unsigned int loopCount, overruns;
   double dtMin, dtMax, dtDesired, sum;


### PR DESCRIPTION
The old behaviour can be activated by calling `setFKComputeVelocity(false)`. 
It defaults to the new behaviour since that is more intuitive. If there are performance issues, it can easily be switched off.