### PR TITLE
Expand physics configuration system

### DIFF
--- a/config/physics/vortex.xml
+++ b/config/physics/vortex.xml
@@ -12,6 +12,11 @@
                    joint_lock_damping="5000000.0"
 />
 
+<bullet_parameters use_mclp_solver="false"
+                   body_linear_damping="0.0"
+                   body_angular_damping="0.0"
+/>
+
 
 <!-- definition of available materials (in addition to "default") -->
 <!-- =============================================================-->

--- a/src/RcsPhysics/BulletRigidBody.h
+++ b/src/RcsPhysics/BulletRigidBody.h
@@ -37,6 +37,7 @@
 #ifndef RCS_BULLETRIGIDBODY_H
 #define RCS_BULLETRIGIDBODY_H
 
+#include "PhysicsConfig.h"
 #include "BulletHingeJoint.h"
 
 
@@ -49,7 +50,7 @@ class BulletRigidBody : public btRigidBody
   friend class BulletSimulation;
 
 public:
-  static BulletRigidBody* create(const RcsBody* body);
+  static BulletRigidBody* create(const RcsBody* body, const PhysicsConfig* config);
   const RcsBody* getBodyPtr() const;
   void getBodyTransform(HTr* A_BI) const;
   void getLocalBodyTransform(HTr* A_PB) const;

--- a/src/RcsPhysics/BulletSimulation.h
+++ b/src/RcsPhysics/BulletSimulation.h
@@ -37,6 +37,8 @@
 #ifndef RCS_BULLETSIMULATION_H
 #define RCS_BULLETSIMULATION_H
 
+#include "PhysicsConfig.h"
+
 #include <PhysicsBase.h>
 
 #include <pthread.h>
@@ -65,6 +67,7 @@ class BulletSimulation : public PhysicsBase
 public:
 
   BulletSimulation(const RcsGraph* graph, const char* configFile=NULL);
+  BulletSimulation(const RcsGraph* graph, const PhysicsConfig* config);
   BulletSimulation(const BulletSimulation& copyFromMe);
   BulletSimulation(const BulletSimulation& copyFromMe, const RcsGraph* newGraph);
   ~BulletSimulation();
@@ -164,7 +167,7 @@ public:
 
 private:
 
-  void initPhysics(const char* physicsConfigFile);
+  void initPhysics(const PhysicsConfig* config);
   void applyControl(double dt);
   void updateSensors();
   bool updatePPSSensor(RcsSensor* sensor);
@@ -189,6 +192,9 @@ private:
 
   BulletDebugDrawer* debugDrawer;
   char* physicsConfigFile;
+
+  double rigidBodyLinearDamping;
+  double rigidBodyAngularDamping;
 
   /*! \brief Private assignment operator to avoid it from being used
    */

--- a/src/RcsPhysics/CMakeLists.txt
+++ b/src/RcsPhysics/CMakeLists.txt
@@ -1,4 +1,5 @@
 SET(RCS_PHYSICS_SRCS
+  PhysicsConfig.cpp
   PhysicsFactory.cpp)
 
 IF(NOT HEADLESS_BUILD)

--- a/src/RcsPhysics/PhysicsConfig.cpp
+++ b/src/RcsPhysics/PhysicsConfig.cpp
@@ -1,9 +1,38 @@
-/*
- * PhysicsConfig.cpp
- *
- *  Created on: Aug 24, 2018
- *      Author: ftreede
- */
+/*******************************************************************************
+
+  Copyright (c) 2017, Honda Research Institute Europe GmbH.
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+
+  3. All advertising materials mentioning features or use of this software
+     must display the following acknowledgement: This product includes
+     software developed by the Honda Research Institute Europe GmbH.
+
+  4. Neither the name of the copyright holder nor the names of its
+     contributors may be used to endorse or promote products derived from
+     this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER "AS IS" AND ANY EXPRESS OR
+  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+  IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY DIRECT, INDIRECT,
+  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+  OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*******************************************************************************/
 
 #include "PhysicsConfig.h"
 

--- a/src/RcsPhysics/PhysicsConfig.cpp
+++ b/src/RcsPhysics/PhysicsConfig.cpp
@@ -1,0 +1,244 @@
+/*
+ * PhysicsConfig.cpp
+ *
+ *  Created on: Aug 24, 2018
+ *      Author: ftreede
+ */
+
+#include "PhysicsConfig.h"
+
+#include <Rcs_resourcePath.h>
+#include <Rcs_macros.h>
+#include <Rcs_parser.h>
+
+namespace Rcs
+{
+
+PhysicsMaterial::PhysicsMaterial()
+{
+  frictionCoefficient = 0.8;
+  rollingFrictionCoefficient = 0.0;
+  restitution = 0.0;
+
+  materialNode = NULL;
+}
+
+PhysicsConfig::PhysicsConfig (const char* xmlFile)
+{
+  // Determine absolute file name of config file and copy the XML file name
+  char filename[256] = "";
+  bool fileExists = Rcs_getAbsoluteFileName (xmlFile, filename);
+
+  if (!fileExists)
+  {
+    RMSG("Resource path is:");
+    Rcs_printResourcePath ();
+    RFATAL("Experiment configuration file \"%s\" not found in "
+	   "ressource path - exiting",
+	   xmlFile ? xmlFile : "NULL");
+  }
+
+  // load xml tree
+  root = parseXMLFile (filename, "Experiment", &doc);
+
+  // load material definitions
+  loadMaterials ();
+}
+
+PhysicsConfig::~PhysicsConfig ()
+{
+  // free xml document
+  xmlFreeDoc (doc);
+
+  // the material map is freed automatically
+}
+
+PhysicsMaterial*
+PhysicsConfig::getMaterial (const std::string& materialName)
+{
+  if (materialName == DEFAULT_MATERIAL_NAME)
+  {
+    // the default material is not stored in the map
+    return &defaultMaterial;
+  }
+
+  // obtain reference from map. using [] automatically creates a new entry for missing objects
+  PhysicsMaterial* mat = &materials[materialName];
+
+  if (mat->materialNode == NULL)
+  {
+    // a newly created material. copy values from default material.
+    *mat = defaultMaterial;
+
+    // create a deep copy of the xml node. We use xmlDocCopy so that the new node is also owned by the doc
+    mat->materialNode = xmlDocCopyNode (mat->materialNode, doc, 1);
+  }
+
+  return mat;
+}
+
+const PhysicsMaterial*
+PhysicsConfig::getMaterial (const std::string& materialName) const
+{
+  if (materialName == DEFAULT_MATERIAL_NAME)
+  {
+    // the default material is not stored in the map
+    return &defaultMaterial;
+  }
+  // try to find in map
+  MaterialMap::const_iterator it = materials.find (materialName);
+
+  if (it != materials.end ())
+  {
+    // found
+    return &it->second;
+  }
+  else
+  {
+    // not found. since the result is const, just return the default material
+    return &defaultMaterial;
+  }
+}
+
+xmlNodePtr
+PhysicsConfig::getXMLRootNode () const
+{
+  return root;
+}
+
+std::vector<std::string>
+PhysicsConfig::getMaterialNames () const
+{
+  std::vector<std::string> result;
+  result.reserve (materials.size () + 1);
+
+  // add default material name
+  result.push_back (DEFAULT_MATERIAL_NAME);
+  // add other material names
+  for (MaterialMap::const_iterator it = materials.begin(); it != materials.end(); it++)
+  {
+    result.push_back (it->first);
+  }
+
+  return result;
+}
+
+PhysicsMaterial*
+PhysicsConfig::getDefaultMaterial ()
+{
+  return &defaultMaterial;
+}
+
+const PhysicsMaterial*
+PhysicsConfig::getDefaultMaterial () const
+{
+  return &defaultMaterial;
+}
+
+void
+PhysicsConfig::loadMaterials ()
+{
+  char msg[256];
+
+  xmlNodePtr node = root->children;
+  while (node)
+  {
+    if (isXMLNodeName (node, "material"))
+    {
+      if (getXMLNodePropertyStringN (node, "name", msg, 256))
+      {
+	PhysicsMaterial* material;
+	if (STREQ(msg, "default")) {
+	  // default material definition
+	  if (!materials.empty()) {
+	    RLOG(1, "%d materials have been defined before the default material. "
+		"They will not be able to use the correct values.", materials.size());
+	  }
+	  material = &defaultMaterial;
+	} else {
+	  // create new material from data
+	  PhysicsMaterial* material = &materials[msg];
+	  // copy values from default material.
+	  *material = defaultMaterial;
+	}
+	material->materialNode = node;
+
+	double value;
+//	char option[64];
+
+	if (getXMLNodePropertyDouble (node, "friction_coefficient", &value))
+	{
+	  material->frictionCoefficient = value;
+	}
+	if (getXMLNodePropertyDouble (node, "rolling_friction_coefficient", &value))
+	{
+	  material->rollingFrictionCoefficient = value;
+	}
+//	if (getXMLNodePropertyDouble (node, "static_friction_scale", &value))
+//	{
+//	  material->setStaticFrictionScale (
+//	      Vx::VxMaterialBase::kFrictionAxisLinear, value);
+//	}
+//	if (getXMLNodePropertyDouble (node, "slip", &value))
+//	{
+//	  material->setSlip (Vx::VxMaterialBase::kFrictionAxisLinear, value);
+//	}
+//	bool isd = false;
+//	if (getXMLNodePropertyBoolString (node, "integrated_slip_displacement",
+//					  &isd))
+//	{
+//	  if (isd)
+//	  {
+//	    material->setIntegratedSlipDisplacement (
+//		Vx::VxMaterial::kIntegratedSlipDisplacementActivated);
+//	  }
+//	  else
+//	  {
+//	    material->setIntegratedSlipDisplacement (
+//		Vx::VxMaterial::kIntegratedSlipDisplacementDeactivated);
+//	  }
+//	}
+//	if (getXMLNodePropertyDouble (node, "slide", &value))
+//	{
+//	  material->setSlide (Vx::VxMaterialBase::kFrictionAxisLinear, value);
+//	}
+//	if (getXMLNodePropertyDouble (node, "compliance", &value))
+//	{
+//	  material->setCompliance (value);
+//	  // as a default, set critical damping
+//	  // material->setDamping(universe->getCriticalDamping(value));
+//	  // from the Vortex documentation:
+//	  // Nearly optimal value of damping is given by:
+//	  // damping = 5*time_step/compliance
+//	  material->setDamping ((5.0 * this->integratorDt) / value);
+//	}
+//	if (getXMLNodePropertyDouble (node, "damping", &value))
+//	{
+//	  material->setDamping (value);
+//	}
+	if (getXMLNodePropertyDouble (node, "restitution", &value))
+	{
+	  material->restitution = value;
+	}
+//	if (getXMLNodePropertyDouble (node, "restitution_threshold", &value))
+//	{
+//	  material->setRestitutionThreshold (value);
+//	}
+//	if (getXMLNodePropertyDouble (node, "adhesive_force", &value))
+//	{
+//	  material->setAdhesiveForce (value);
+//	}
+      }
+      else
+      {
+	RLOG(1, "Found a material entry without a name property, so"
+	     " it is ignored");
+      }
+    }
+
+    node = node->next;
+  }
+
+}
+
+} /* namespace Rcs */

--- a/src/RcsPhysics/PhysicsConfig.cpp
+++ b/src/RcsPhysics/PhysicsConfig.cpp
@@ -23,38 +23,38 @@ PhysicsMaterial::PhysicsMaterial()
   materialNode = NULL;
 }
 
-PhysicsConfig::PhysicsConfig (const char* xmlFile)
+PhysicsConfig::PhysicsConfig(const char* xmlFile)
 {
   // Determine absolute file name of config file and copy the XML file name
   char filename[256] = "";
-  bool fileExists = Rcs_getAbsoluteFileName (xmlFile, filename);
+  bool fileExists = Rcs_getAbsoluteFileName(xmlFile, filename);
 
   if (!fileExists)
   {
     RMSG("Resource path is:");
-    Rcs_printResourcePath ();
+    Rcs_printResourcePath();
     RFATAL("Experiment configuration file \"%s\" not found in "
-	   "ressource path - exiting",
-	   xmlFile ? xmlFile : "NULL");
+           "ressource path - exiting",
+           xmlFile ? xmlFile : "NULL");
   }
 
   // load xml tree
-  root = parseXMLFile (filename, "Experiment", &doc);
+  root = parseXMLFile(filename, "content", &doc);
+  RCHECK(root);
 
   // load material definitions
-  loadMaterials ();
+  loadMaterials();
 }
 
-PhysicsConfig::~PhysicsConfig ()
+PhysicsConfig::~PhysicsConfig()
 {
   // free xml document
-  xmlFreeDoc (doc);
+  xmlFreeDoc(doc);
 
   // the material map is freed automatically
 }
 
-PhysicsMaterial*
-PhysicsConfig::getMaterial (const std::string& materialName)
+PhysicsMaterial* PhysicsConfig::getMaterial(const std::string& materialName)
 {
   if (materialName == DEFAULT_MATERIAL_NAME)
   {
@@ -71,14 +71,13 @@ PhysicsConfig::getMaterial (const std::string& materialName)
     *mat = defaultMaterial;
 
     // create a deep copy of the xml node. We use xmlDocCopy so that the new node is also owned by the doc
-    mat->materialNode = xmlDocCopyNode (mat->materialNode, doc, 1);
+    mat->materialNode = xmlDocCopyNode(mat->materialNode, doc, 1);
   }
 
   return mat;
 }
 
-const PhysicsMaterial*
-PhysicsConfig::getMaterial (const std::string& materialName) const
+const PhysicsMaterial* PhysicsConfig::getMaterial(const std::string& materialName) const
 {
   if (materialName == DEFAULT_MATERIAL_NAME)
   {
@@ -86,9 +85,9 @@ PhysicsConfig::getMaterial (const std::string& materialName) const
     return &defaultMaterial;
   }
   // try to find in map
-  MaterialMap::const_iterator it = materials.find (materialName);
+  MaterialMap::const_iterator it = materials.find(materialName);
 
-  if (it != materials.end ())
+  if (it != materials.end())
   {
     // found
     return &it->second;
@@ -100,80 +99,79 @@ PhysicsConfig::getMaterial (const std::string& materialName) const
   }
 }
 
-xmlNodePtr
-PhysicsConfig::getXMLRootNode () const
+xmlNodePtr PhysicsConfig::getXMLRootNode() const
 {
   return root;
 }
 
-std::vector<std::string>
-PhysicsConfig::getMaterialNames () const
+std::vector<std::string> PhysicsConfig::getMaterialNames() const
 {
   std::vector<std::string> result;
-  result.reserve (materials.size () + 1);
+  result.reserve(materials.size() + 1);
 
   // add default material name
-  result.push_back (DEFAULT_MATERIAL_NAME);
+  result.push_back(DEFAULT_MATERIAL_NAME);
   // add other material names
   for (MaterialMap::const_iterator it = materials.begin(); it != materials.end(); it++)
   {
-    result.push_back (it->first);
+    result.push_back(it->first);
   }
 
   return result;
 }
 
-PhysicsMaterial*
-PhysicsConfig::getDefaultMaterial ()
+PhysicsMaterial* PhysicsConfig::getDefaultMaterial()
 {
   return &defaultMaterial;
 }
 
-const PhysicsMaterial*
-PhysicsConfig::getDefaultMaterial () const
+const PhysicsMaterial* PhysicsConfig::getDefaultMaterial() const
 {
   return &defaultMaterial;
 }
 
-void
-PhysicsConfig::loadMaterials ()
+void PhysicsConfig::loadMaterials()
 {
   char msg[256];
 
   xmlNodePtr node = root->children;
   while (node)
   {
-    if (isXMLNodeName (node, "material"))
+    if (isXMLNodeName(node, "material"))
     {
-      if (getXMLNodePropertyStringN (node, "name", msg, 256))
+      if (getXMLNodePropertyStringN(node, "name", msg, 256))
       {
-	PhysicsMaterial* material;
-	if (STREQ(msg, "default")) {
-	  // default material definition
-	  if (!materials.empty()) {
-	    RLOG(1, "%d materials have been defined before the default material. "
-		"They will not be able to use the correct values.", materials.size());
-	  }
-	  material = &defaultMaterial;
-	} else {
-	  // create new material from data
-	  PhysicsMaterial* material = &materials[msg];
-	  // copy values from default material.
-	  *material = defaultMaterial;
-	}
-	material->materialNode = node;
+        PhysicsMaterial* material;
+        if (STREQ(msg, "default"))
+        {
+          // default material definition
+          if (!materials.empty())
+          {
+            RLOG(1, "%lu materials have been defined before the default material. "
+                    "They will not be able to use the correct values.", materials.size());
+          }
+          material = &defaultMaterial;
+        }
+        else
+        {
+          // create new material from data
+          material = &materials[msg];
+          // copy values from default material.
+          *material = defaultMaterial;
+        }
+        material->materialNode = node;
 
-	double value;
+        double value;
 //	char option[64];
 
-	if (getXMLNodePropertyDouble (node, "friction_coefficient", &value))
-	{
-	  material->frictionCoefficient = value;
-	}
-	if (getXMLNodePropertyDouble (node, "rolling_friction_coefficient", &value))
-	{
-	  material->rollingFrictionCoefficient = value;
-	}
+        if (getXMLNodePropertyDouble(node, "friction_coefficient", &value))
+        {
+          material->frictionCoefficient = value;
+        }
+        if (getXMLNodePropertyDouble(node, "rolling_friction_coefficient", &value))
+        {
+          material->rollingFrictionCoefficient = value;
+        }
 //	if (getXMLNodePropertyDouble (node, "static_friction_scale", &value))
 //	{
 //	  material->setStaticFrictionScale (
@@ -216,10 +214,10 @@ PhysicsConfig::loadMaterials ()
 //	{
 //	  material->setDamping (value);
 //	}
-	if (getXMLNodePropertyDouble (node, "restitution", &value))
-	{
-	  material->restitution = value;
-	}
+        if (getXMLNodePropertyDouble(node, "restitution", &value))
+        {
+          material->restitution = value;
+        }
 //	if (getXMLNodePropertyDouble (node, "restitution_threshold", &value))
 //	{
 //	  material->setRestitutionThreshold (value);
@@ -231,8 +229,8 @@ PhysicsConfig::loadMaterials ()
       }
       else
       {
-	RLOG(1, "Found a material entry without a name property, so"
-	     " it is ignored");
+        RLOG(1, "Found a material entry without a name property, so"
+                " it is ignored");
       }
     }
 

--- a/src/RcsPhysics/PhysicsConfig.cpp
+++ b/src/RcsPhysics/PhysicsConfig.cpp
@@ -10,6 +10,7 @@
 #include <Rcs_resourcePath.h>
 #include <Rcs_macros.h>
 #include <Rcs_parser.h>
+#include <Rcs_utils.h>
 
 namespace Rcs
 {
@@ -25,6 +26,9 @@ PhysicsMaterial::PhysicsMaterial()
 
 PhysicsConfig::PhysicsConfig(const char* xmlFile)
 {
+  // store passed file name
+  this->xmlFile = String_clone(xmlFile);
+
   // Determine absolute file name of config file and copy the XML file name
   char filename[256] = "";
   bool fileExists = Rcs_getAbsoluteFileName(xmlFile, filename);
@@ -60,6 +64,9 @@ PhysicsConfig::~PhysicsConfig()
 {
   // free xml document
   xmlFreeDoc(doc);
+
+  // free config file name
+  RFREE(this->xmlFile);
 
   // the material map is freed automatically
 }
@@ -109,14 +116,19 @@ const PhysicsMaterial* PhysicsConfig::getMaterial(const std::string& materialNam
   }
 }
 
+const char* PhysicsConfig::getConfigFileName() const
+{
+  return xmlFile;
+}
+
 xmlNodePtr PhysicsConfig::getXMLRootNode() const
 {
   return root;
 }
 
-std::vector<std::string> PhysicsConfig::getMaterialNames() const
+PhysicsConfig::MaterialNameList PhysicsConfig::getMaterialNames() const
 {
-  std::vector<std::string> result;
+  MaterialNameList result;
   result.reserve(materials.size() + 1);
 
   // add default material name

--- a/src/RcsPhysics/PhysicsConfig.h
+++ b/src/RcsPhysics/PhysicsConfig.h
@@ -65,6 +65,7 @@ class PhysicsConfig
 {
 public:
   typedef std::map<std::string, PhysicsMaterial> MaterialMap;
+  typedef std::vector<std::string> MaterialNameList;
 
   /**
    * Load the physics configuration from the given xml file.
@@ -112,7 +113,12 @@ public:
   /**
    * Get the names of all registered materials.
    */
-  std::vector<std::string> getMaterialNames() const;
+  MaterialNameList getMaterialNames() const;
+
+  /**
+   * Return the name of the xml file the config was loaded from.
+   */
+  const char* getConfigFileName() const;
 
   /**
    * Return the root xml node of the config file.
@@ -124,6 +130,9 @@ private:
 
   // load the material data from xml
   void loadMaterials();
+
+  // full path of xml file
+  char* xmlFile;
 
   // xml document, owns all xml objects
   xmlDocPtr doc;

--- a/src/RcsPhysics/PhysicsConfig.h
+++ b/src/RcsPhysics/PhysicsConfig.h
@@ -32,16 +32,16 @@ namespace Rcs
 struct PhysicsMaterial
 {
   // coefficient of linear friction
-  double frictionCoefficient = 0.8;
+  double frictionCoefficient;
   // coefficient of angular (rolling) friction.
-  double rollingFrictionCoefficient = 0.0;
+  double rollingFrictionCoefficient;
   // bouncyness
-  double restitution = 0.0;
+  double restitution;
   // TODO add others?
 
   // xml node whose properties defined this material.
   // allows physics engines to load engine-specific attributes
-  xmlNodePtr materialNode = NULL;
+  xmlNodePtr materialNode;
 
   // default constructor applies default values
   PhysicsMaterial();
@@ -69,10 +69,8 @@ public:
   /**
    * Load the physics configuration from the given xml file.
    */
-  explicit
-  PhysicsConfig (const char* xmlFile);
-  virtual
-  ~PhysicsConfig ();
+  explicit PhysicsConfig(const char* xmlFile);
+  virtual ~PhysicsConfig();
 
   /**
    * Obtain the material properties of the named material.
@@ -87,8 +85,7 @@ public:
    * @param materialName material name to look up
    * @return named material
    */
-  PhysicsMaterial*
-  getMaterial (const std::string& materialName);
+  PhysicsMaterial* getMaterial(const std::string& materialName);
 
   /**
    * Obtain the material properties of the named material.
@@ -100,40 +97,33 @@ public:
    * @param materialName material name to look up
    * @return named material
    */
-  const PhysicsMaterial*
-  getMaterial (const std::string& materialName) const;
+  const PhysicsMaterial* getMaterial(const std::string& materialName) const;
 
   /**
    * Get a reference to the default material data.
    */
-  PhysicsMaterial*
-  getDefaultMaterial();
+  PhysicsMaterial* getDefaultMaterial();
 
   /**
    * Get a reference to the default material data.
    */
-  const PhysicsMaterial*
-  getDefaultMaterial() const;
+  const PhysicsMaterial* getDefaultMaterial() const;
 
   /**
    * Get the names of all registered materials.
    */
-  std::vector<std::string>
-  getMaterialNames () const;
+  std::vector<std::string> getMaterialNames() const;
 
   /**
    * Return the root xml node of the config file.
    */
-  xmlNodePtr
-  getXMLRootNode () const;
-
+  xmlNodePtr getXMLRootNode() const;
 
 
 private:
 
   // load the material data from xml
-  void
-  loadMaterials ();
+  void loadMaterials();
 
   // xml document, owns all xml objects
   xmlDocPtr doc;

--- a/src/RcsPhysics/PhysicsConfig.h
+++ b/src/RcsPhysics/PhysicsConfig.h
@@ -1,9 +1,38 @@
-/*
- * PhysicsConfig.h
- *
- *  Created on: Aug 24, 2018
- *      Author: ftreede
- */
+/*******************************************************************************
+
+  Copyright (c) 2017, Honda Research Institute Europe GmbH.
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+
+  3. All advertising materials mentioning features or use of this software
+     must display the following acknowledgement: This product includes
+     software developed by the Honda Research Institute Europe GmbH.
+
+  4. Neither the name of the copyright holder nor the names of its
+     contributors may be used to endorse or promote products derived from
+     this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER "AS IS" AND ANY EXPRESS OR
+  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+  IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY DIRECT, INDIRECT,
+  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+  OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*******************************************************************************/
 
 #ifndef SRC_RCSPHYSICS_PHYSICSCONFIG_H_
 #define SRC_RCSPHYSICS_PHYSICSCONFIG_H_

--- a/src/RcsPhysics/PhysicsConfig.h
+++ b/src/RcsPhysics/PhysicsConfig.h
@@ -1,0 +1,151 @@
+/*
+ * PhysicsConfig.h
+ *
+ *  Created on: Aug 24, 2018
+ *      Author: ftreede
+ */
+
+#ifndef SRC_RCSPHYSICS_PHYSICSCONFIG_H_
+#define SRC_RCSPHYSICS_PHYSICSCONFIG_H_
+
+#include <libxml/tree.h>
+
+#include <map>
+#include <vector>
+#include <string>
+
+namespace Rcs
+{
+
+/**
+ * Name of the default material.
+ *
+ * When a PhysicsMaterial is created, it's values are initialized to those of the default material.
+ *
+ * Note that later modifications of the parameter values will not be used.
+ */
+#define DEFAULT_MATERIAL_NAME "default"
+
+/**
+ * Definition of the material properties used by the physics simulator.
+ */
+struct PhysicsMaterial
+{
+  // coefficient of linear friction
+  double frictionCoefficient = 0.8;
+  // coefficient of angular (rolling) friction.
+  double rollingFrictionCoefficient = 0.0;
+  // bouncyness
+  double restitution = 0.0;
+  // TODO add others?
+
+  // xml node whose properties defined this material.
+  // allows physics engines to load engine-specific attributes
+  xmlNodePtr materialNode = NULL;
+
+  // default constructor applies default values
+  PhysicsMaterial();
+};
+
+/**
+ * Physics engine configuration parameters.
+ *
+ * This is the C++-side model of the physics configuration XML file.
+ *
+ * The first part are the PhysicsMaterial definitions. Every material definition
+ * holds material properties such as friction coefficients. When creating a shape,
+ * the physics engine will use the shape's material property to select a named
+ * material definition.
+ * Some physics engines cannot use different material parameters for shapes on the same body.
+ * In that case, they should use the values from the material of the first physics shape.
+ *
+ * To support physics engine specific parameters, the object also holds the parsed xml tree.
+ */
+class PhysicsConfig
+{
+public:
+  typedef std::map<std::string, PhysicsMaterial> MaterialMap;
+
+  /**
+   * Load the physics configuration from the given xml file.
+   */
+  explicit
+  PhysicsConfig (const char* xmlFile);
+  virtual
+  ~PhysicsConfig ();
+
+  /**
+   * Obtain the material properties of the named material.
+   *
+   * If a material of the given name doesn't exist, a new one is inserted,
+   * copying it's data from the default material.
+   *
+   * The returned material object can be modified.
+   *
+   * The returned object is owned by the PhysicsConfig object.
+   *
+   * @param materialName material name to look up
+   * @return named material
+   */
+  PhysicsMaterial*
+  getMaterial (const std::string& materialName);
+
+  /**
+   * Obtain the material properties of the named material.
+   *
+   * If a material of the given name doesn't exist, the default material is returned.
+   *
+   * The returned object is owned by the PhysicsConfig object.
+   *
+   * @param materialName material name to look up
+   * @return named material
+   */
+  const PhysicsMaterial*
+  getMaterial (const std::string& materialName) const;
+
+  /**
+   * Get a reference to the default material data.
+   */
+  PhysicsMaterial*
+  getDefaultMaterial();
+
+  /**
+   * Get a reference to the default material data.
+   */
+  const PhysicsMaterial*
+  getDefaultMaterial() const;
+
+  /**
+   * Get the names of all registered materials.
+   */
+  std::vector<std::string>
+  getMaterialNames () const;
+
+  /**
+   * Return the root xml node of the config file.
+   */
+  xmlNodePtr
+  getXMLRootNode () const;
+
+
+
+private:
+
+  // load the material data from xml
+  void
+  loadMaterials ();
+
+  // xml document, owns all xml objects
+  xmlDocPtr doc;
+  // document root node
+  xmlNodePtr root;
+
+  // default material data
+  PhysicsMaterial defaultMaterial;
+  // map from material name to material data
+  MaterialMap materials;
+};
+
+} /* namespace Rcs */
+
+#endif /* SRC_RCSPHYSICS_PHYSICSCONFIG_H_ */

--- a/src/RcsPhysics/PhysicsFactory.cpp
+++ b/src/RcsPhysics/PhysicsFactory.cpp
@@ -70,7 +70,37 @@ Rcs::PhysicsBase* Rcs::PhysicsFactory::create(const std::string& className,
 
   if (it != instance()->constructorMap.end())
   {
-    sim = it->second(className, graph, cfgFile);
+    PhysicsConfig config(cfgFile);
+    sim = it->second(className, graph, &config);
+  }
+  else
+  {
+    REXEC(1)
+    {
+      RMSG("Couldn't instantiate physics engine \"%s\"", className.c_str());
+      RMSG("Options are:");
+      print();
+    }
+  }
+
+  return sim;
+}
+
+/*******************************************************************************
+ * Creates the physics engine for className and the given graph and config obj
+ ******************************************************************************/
+Rcs::PhysicsBase* Rcs::PhysicsFactory::create(const std::string& className,
+                                              RcsGraph* graph,
+                                              const PhysicsConfig* config)
+{
+  Rcs::PhysicsBase* sim = NULL;
+  std::map<std::string, PhysicsCreateFunction>::iterator it;
+
+  it = instance()->constructorMap.find(className);
+
+  if (it != instance()->constructorMap.end())
+  {
+    sim = it->second(className, graph, config);
   }
   else
   {

--- a/src/RcsPhysics/PhysicsFactory.h
+++ b/src/RcsPhysics/PhysicsFactory.h
@@ -37,6 +37,8 @@
 #ifndef RCS_PHYSICSFACTORY_H
 #define RCS_PHYSICSFACTORY_H
 
+#include "PhysicsConfig.h"
+
 #include <PhysicsBase.h>
 
 #include <string>
@@ -67,6 +69,17 @@ public:
    */
   static PhysicsBase* create(const std::string& className, RcsGraph* graph,
                              const char* cfgFile);
+  /*!
+   * \brief Creates a new Physics simulation instance by name using the
+   *        appropriate registered construction function.
+   * \param className The name with which the physics is registered at the
+   *        factory
+   * \param graph The underlying graph for the kinematics
+   * \param config Loaded physics configuration
+   * \return New PhysicsBase instance
+   */
+  static PhysicsBase* create(const std::string& className, RcsGraph* graph,
+                             const PhysicsConfig* config);
 
   /*!
    * \brief Prints the list of all registered physics simulations to stdout.
@@ -77,7 +90,7 @@ private:
 
   typedef PhysicsBase* (*PhysicsCreateFunction)(std::string className,
                                                 RcsGraph* graph,
-                                                const char* cfgFile);
+                                                const PhysicsConfig* config);
 
   /*! \brief Private constructor because PhysicsFactory is a singleton
    */
@@ -136,9 +149,9 @@ public:
    * \return New physics simulation instance of type T
    */
   static PhysicsBase* create(std::string className, RcsGraph* graph,
-                             const char* cfgFile)
+                             const PhysicsConfig* config)
   {
-    return new T(graph, cfgFile);
+    return new T(graph, config);
   }
 };
 

--- a/src/RcsPhysics/VortexSimulation.h
+++ b/src/RcsPhysics/VortexSimulation.h
@@ -37,6 +37,8 @@
 #ifndef RCS_VORTEXSIMULATION_H
 #define RCS_VORTEXSIMULATION_H
 
+#include "PhysicsConfig.h"
+
 #include <PhysicsBase.h>
 
 #include <pthread.h>
@@ -75,6 +77,20 @@ public:
    */
   VortexSimulation(const RcsGraph* graph,
                    const char* cfgFile="config/physics/vortex.xml",
+                   bool groundPlane=true);
+
+  /*! \brief Constructs an instance of a physics simulation.
+   *
+   *  \param[in] graph         Pointer to the RcsGraph structure that the
+   *                           simulation should correspond to.
+   *  \param[in] config        Config with the default parameters of the
+   *                           simulation. For details, see \ref initPhysics
+   *                           and \ref initMaterial.
+   *  \param[in] groundPlane   If true, a ground plane in the x-y plane on
+   *                           height z=0 is created.
+   */
+  VortexSimulation(const RcsGraph* graph,
+                   const PhysicsConfig* config,
                    bool groundPlane=true);
   VortexSimulation(const VortexSimulation& copyFromMe,
                    const RcsGraph* newGraph);
@@ -262,9 +278,9 @@ public:
 
 private:
 
-  bool initSettings(const char* configFile);
+  bool initSettings(const PhysicsConfig* config);
 
-  void initMaterial(const char* materialFile=NULL);
+  void initMaterial(const PhysicsConfig* config);
 
   /*! \brief Creates a physical body and adds it to the simulation. All
    *         collision shapes are subsumed into one composite shape, which
@@ -287,7 +303,7 @@ private:
   void updateTransformations();
   void applyControl(double dt);
   void applyControl2(double dt);
-  void initPhysics(const char* physicsConfigFile, bool groundPlane);
+  void initPhysics(const PhysicsConfig* physicsConfig, bool groundPlane);
   bool updateFTS(RcsSensor* sensor);
   bool updateJointTorqueSensor(RcsSensor* sensor);
   bool updateContactForceSensor(RcsSensor* sensor);


### PR DESCRIPTION
- PhysicsConfig object stores loaded physics configuration, so it can be modified in code independently from the physics engine implementation.
- Use PhysicsConfig instead of config file path in PhysicsFactory.
- Bullet engine supports physics configuration.