### PR TITLE
Apply friction_model setting for rolling friction too.

### DIFF
--- a/src/RcsPhysics/VortexSimulation.cpp
+++ b/src/RcsPhysics/VortexSimulation.cpp
@@ -493,15 +493,27 @@ void Rcs::VortexSimulation::initMaterial(const PhysicsConfig* config)
       {
         material->setFrictionModel(Vx::VxMaterialBase::kFrictionAxisLinear,
                                    Vx::VxMaterialBase::kFrictionModelBox);
+        material->setFrictionModel(Vx::VxMaterialBase::kFrictionAxisAngularPrimary,
+                                   Vx::VxMaterialBase::kFrictionModelBox);
+        material->setFrictionModel(Vx::VxMaterialBase::kFrictionAxisAngularSecondary,
+                                   Vx::VxMaterialBase::kFrictionModelBox);
       }
       else if (STRCASEEQ(option, "ScaledBox"))
       {
         material->setFrictionModel(Vx::VxMaterialBase::kFrictionAxisLinear,
                                    Vx::VxMaterialBase::kFrictionModelScaledBox);
+        material->setFrictionModel(Vx::VxMaterialBase::kFrictionAxisAngularPrimary,
+                                   Vx::VxMaterialBase::kFrictionModelScaledBox);
+        material->setFrictionModel(Vx::VxMaterialBase::kFrictionAxisAngularSecondary,
+                                   Vx::VxMaterialBase::kFrictionModelScaledBox);
       }
       else if (STRCASEEQ(option, "ScaledBoxFast"))
       {
         material->setFrictionModel(Vx::VxMaterialBase::kFrictionAxisLinear,
+                                   Vx::VxMaterialBase::kFrictionModelScaledBoxFast);
+        material->setFrictionModel(Vx::VxMaterialBase::kFrictionAxisAngularPrimary,
+                                   Vx::VxMaterialBase::kFrictionModelScaledBoxFast);
+        material->setFrictionModel(Vx::VxMaterialBase::kFrictionAxisAngularSecondary,
                                    Vx::VxMaterialBase::kFrictionModelScaledBoxFast);
       }
       else


### PR DESCRIPTION
The default friction model is NONE, so without this, the rolling
friction coefficient has no effect.