### PR TITLE
Fix Externals.cmake on non-HRI systems

### DIFF
--- a/cmake/Externals.cmake
+++ b/cmake/Externals.cmake
@@ -3,11 +3,9 @@
 # Settings for finding files and directories
 #
 ################################################################################
-#SET(HGR   $ENV{SIT})
-#SET(MKPLT $ENV{MAKEFILE_PLATFORM})
 
-string (REPLACE "\\" "/" HGR $ENV{SIT})
-string (REPLACE "\\" "/" MKPLT $ENV{MAKEFILE_PLATFORM})
+string (REPLACE "\\" "/" HGR "$ENV{SIT}")
+string (REPLACE "\\" "/" MKPLT "$ENV{MAKEFILE_PLATFORM}")
 
 ################################################################################
 #


### PR DESCRIPTION
If the `SIT` environment variable is not defined, the `string(REPLACE ...)` command fails due to a missing parameter. This change fixes it by passing an empty string instead.