### PR TITLE
Fix duplicate function with USE_WM5=OFF

### DIFF
--- a/src/RcsCore/Rcs_intersectionWM5.cpp
+++ b/src/RcsCore/Rcs_intersectionWM5.cpp
@@ -686,13 +686,6 @@ extern "C" {
     return false;
   }
 
-  bool RcsBody_boxify(RcsBody* self, int computeType)
-  {
-    RLOG(4, "Body boxification requires GeometricTools library - "
-         "not available");
-    return false;
-  }
-
 } // extern "C"
 
 #endif


### PR DESCRIPTION
RcsBody_boxify got moved, so the fallback dummy should be removed too.