### PR TITLE
Small fixes for URDF graphs

### DIFF
--- a/src/RcsCore/Rcs_HTr.c
+++ b/src/RcsCore/Rcs_HTr.c
@@ -239,7 +239,7 @@ void HTr_fprint(FILE* fd, const HTr* A)
 {
   if (A == NULL)
   {
-    fprintf(fd, "HTr is NULL");
+    fprintf(fd, "HTr is NULL\n");
     return;
   }
 

--- a/src/RcsCore/Rcs_URDFParser.c
+++ b/src/RcsCore/Rcs_URDFParser.c
@@ -516,7 +516,10 @@ RcsJoint* parseJointURDF(xmlNode* node)
   }
 
   jnt->q0 = (jnt->q_max + jnt->q_min) / 2.0;
-  jnt->q_init = jnt->q0;
+
+  // Setting to zero since joint coupling logic in URDF does not consider q_init and any other value
+  // leads to a difference between URDF and RCS coupled joint computations
+  jnt->q_init = 0.0;
 
   // Create coupled joint if mimic tag is present
   xmlNodePtr mimicNode = getXMLChildByName(node, "mimic");
@@ -707,7 +710,7 @@ static void connectURDF(xmlNode* node, RcsBody** bdyVec, RcsJoint** jntVec,
           RLOG(0, "TODO: Check axis transform for joint \"%s\"", jnt->name);
           double A_JN[3][3];
           Mat3d_transpose(A_JN, A_NJ);
-          Mat3d_postMulSelf(jnt->A_JP->rot, A_JN);
+          Mat3d_postMulSelf(childBody->A_BP->rot, A_JN);
         }
       }    // Axis is skew
 

--- a/src/RcsCore/Rcs_graph.c
+++ b/src/RcsCore/Rcs_graph.c
@@ -2917,6 +2917,15 @@ void RcsGraph_makeJointsConsistent(RcsGraph* self)
       }
     }
 
+    // In case min and max values are switched (could happen if for example coupled joints have a negative multiplier)
+    if (q_min > q_max)
+    {
+      double q_tmp = q_min;
+      q_min = q_max;
+      q_max = q_tmp;
+    }
+
+
     JNT->q_min  = q_min;
     JNT->q_max  = q_max;
     JNT->q0     = q0;


### PR DESCRIPTION
Hi Michael,

I encountered some issues with the coupled joints being handled differently in URDF compared to the Rcs default.
q_init does not exist there and thus needs to be assumed to be 0.0 because the Rcs calculation is 
"q_slave = q_slave_init + coupling_factor * (q_master - q_init)"

in URDF it is

"q_slave = coupling_factor * q_master

Also I added a small fix for the case that q_min and q_max are switched (which could happen in case of negative coupling factors)