### PR TITLE
Inconsistent joint order after calling connectURDF

### DIFF
--- a/src/RcsCore/Rcs_URDFParser.c
+++ b/src/RcsCore/Rcs_URDFParser.c
@@ -560,11 +560,14 @@ static void makeJointOrderConsistent(RcsBody* bdy)
         RcsJoint* prevJnt = RcsBody_lastJointBeforeBody(parentBdy);
         RCSBODY_TRAVERSE_JOINTS(BODY)
         {
-            RLOG(0, "Joint \"%s\" previous joint was \"%s\", previous joint now \"%s\"",
-                 JNT->name, (JNT->prev == NULL) ? "NULL" : JNT->prev->name,
-                 (prevJnt == NULL) ? "NULL" : prevJnt->name);
-            JNT->prev = prevJnt;
-            JNT->next = NULL;
+            if(prevJnt != JNT->prev)
+            {
+                RLOG(5, "Joint \"%s\" previous joint was \"%s\", previous joint now \"%s\"",
+                     JNT->name, (JNT->prev == NULL) ? "NULL" : JNT->prev->name,
+                     (prevJnt == NULL) ? "NULL" : prevJnt->name);
+                JNT->prev = prevJnt;
+                JNT->next = NULL;
+            }
         }
     }
 }


### PR DESCRIPTION
After calling `connectURDF`, the `jnt->prev` information stored in a `Rcsjoint` might be incorrect when the order of joints in the urdf file does not match the order in the kinematic chain. This pull requests fixes this issue.