### PR TITLE
Minor extension of the task region interface for the Box interval

### DIFF
--- a/src/RcsCore/TaskRegionBoxInterval.h
+++ b/src/RcsCore/TaskRegionBoxInterval.h
@@ -100,7 +100,7 @@ public:
 
 private:
 
-  std::vector<double> bbMin, bbMax, maxStep, bbMean;
+  std::vector<double> bbMin, bbMax, bbMean, maxStep;
   double slowDownRatio;
 };
 

--- a/src/RcsCore/TaskRegionBoxInterval.h
+++ b/src/RcsCore/TaskRegionBoxInterval.h
@@ -100,7 +100,7 @@ public:
 
 private:
 
-  std::vector<double> bbMin, bbMax, maxStep;
+  std::vector<double> bbMin, bbMax, maxStep, bbMean;
   double slowDownRatio;
 };
 


### PR DESCRIPTION
This is a very simple extension of the TaskRegionBoxInterval interface to allow the user to specify (manually) the center of the region, using the "mean" field. 

If the "mean" field is not specified, then it works as before (the center of the region is set according to the dx values). 